### PR TITLE
change declaration of Base layer

### DIFF
--- a/theanets/layers.py
+++ b/theanets/layers.py
@@ -240,12 +240,7 @@ class Registrar(type):
         return cls._registry[key.lower()](*args, **kwargs)
 
 # py2k and py3k have different metaclass syntax. :-/
-if sys.version_info.major <= 2:
-    class Base(object):
-        __metaclass__ = Registrar
-else:
-    class Base(metaclass=Registrar):
-        pass
+Base = Registrar(str('Base'), (), {})
 
 
 class Layer(Base):


### PR DESCRIPTION
This was giving me a syntax error in python 2.7. I don't know much about python3, but I made this change following https://wiki.python.org/moin/PortingToPy3k/BilingualQuickRef#metaclasses and it seems to work in both versions now.