### PR TITLE
Simpler assignment of the optimize alg

### DIFF
--- a/theanets/main.py
+++ b/theanets/main.py
@@ -302,7 +302,7 @@ class Experiment:
         sets = dict(train_set=train_set, valid_set=valid_set, cg_set=train_set)
 
         # set up training algorithm(s)
-        optimize = self.kwargs.get('optimize', 'rmsprop')
+        optimize = optimize or self.kwargs.get('optimize', 'rmsprop')
         
         if isinstance(optimize, str):
             optimize = optimize.split()

--- a/theanets/main.py
+++ b/theanets/main.py
@@ -302,10 +302,8 @@ class Experiment:
         sets = dict(train_set=train_set, valid_set=valid_set, cg_set=train_set)
 
         # set up training algorithm(s)
-        if optimize is None:
-            optimize = self.kwargs.get('optimize')
-        if not optimize:
-            optimize = 'rmsprop'  # use rmsprop if nothing else is defined.
+        optimize = self.kwargs.get('optimize', 'rmsprop')
+        
         if isinstance(optimize, str):
             optimize = optimize.split()
 


### PR DESCRIPTION
Was trying to get recurrent-memory example to work, turns out I had an out of date version of theanets installed (the one you get with `pip install` isn't compatible with that example). While I was troubleshooting I noticed this small change. I also had to comment out `climate.enable_default_logging()` as I get an error `UnsupportedOperation: fileno` (I'm running this on Windows). The `climate` module seems to be mostly working other than that once I installed http://www.lfd.uci.edu/~gohlke/pythonlibs/#curses.