### PR TITLE
netcdf_file expects a filename not a file object

### DIFF
--- a/examples/lstm_chime.py
+++ b/examples/lstm_chime.py
@@ -66,5 +66,5 @@ e = theanets.Experiment(
     input_noise=0.6,
     max_gradient_norm=10,
 )
-e.train(batches(scipy.io.netcdf_file(open(TRAIN_NC))),
-        batches(scipy.io.netcdf_file(open(VALID_NC))))
+e.train(batches(scipy.io.netcdf_file(TRAIN_NC)),
+        batches(scipy.io.netcdf_file(VALID_NC)))


### PR DESCRIPTION
file objects can be used but to do so the mode must be set to 'rb' (i.e. `scipy.io.netcdf_file(open(TRAIN_NC, 'rb'))` )