### PR TITLE
support for sparse input features

### DIFF
--- a/theanets/dataset.py
+++ b/theanets/dataset.py
@@ -139,7 +139,7 @@ class Dataset:
             axis = 1 if len(samples.shape) == 3 else 0
         slices = [slice(None), slice(None)][:axis + 1]
         for i in range(0, samples.shape[axis], self.batch_size):
-            slices[axis] = slice(i, i + self.batch_size)
+            slices[axis] = slice(i, min(i + self.batch_size, samples.shape[0]))
             batch = [samples[tuple(slices)]]
             if labels is not None:
                 batch.append(labels[tuple(slices)])

--- a/theanets/feedforward.py
+++ b/theanets/feedforward.py
@@ -81,6 +81,7 @@ import numpy as np
 import pickle
 import theano
 import theano.tensor as TT
+import theano.sparse as SS
 
 from theano.sandbox.rng_mrg import MRG_RandomStreams as RandomStreams
 
@@ -163,6 +164,9 @@ class Network(object):
         number of time steps, or for classifier networks where the prior
         proabibility of one class is significantly different than another. The
         default is not to use weighted outputs.
+    sparse_input : bool, optional
+        If True, the network will expect input represented as a sparse (csr)
+        matrix. Currently only supported for feedforward networks.
 
     Attributes
     ----------
@@ -197,7 +201,10 @@ class Network(object):
             A list of the variables that this network requires as inputs.
         '''
         # x represents our network's input.
-        self.x = TT.matrix('x')
+        if self.is_sparse_input:
+            self.x = SS.csr_matrix('x',dtype=FLOAT)
+        else:
+            self.x = TT.matrix('x')
 
         # the weight array is provided to ensure that different target values
         # are taken into account with different weights during optimization.
@@ -333,6 +340,11 @@ class Network(object):
             nin=sizes[-1] if back <= 1 else sizes[-back:],
             nout=self.kwargs['layers'][-1],
             activation=self.output_activation))
+
+    @property
+    def is_sparse_input(self):
+        '''True iff the network expects sparse input vectors.'''
+        return bool(self.kwargs.get('sparse_input'))
 
     @property
     def is_weighted(self):

--- a/theanets/layers.py
+++ b/theanets/layers.py
@@ -14,7 +14,7 @@ logging = climate.get_logger(__name__)
 
 FLOAT = theano.config.floatX
 
-def myDot(x, y):
+def _dot(x, y):
     if isinstance(x, SS.SparseVariable):
         return SS.structured_dot(x,y)
     else:
@@ -535,7 +535,7 @@ class Feedforward(Layer):
         '''
         if not hasattr(inputs, '__len__'):
             inputs = (inputs, )
-        xs = (myDot(x, self.find(str(i))) for i, x in enumerate(inputs))
+        xs = (_dot(x, self.find(str(i))) for i, x in enumerate(inputs))
         output = self.activate(sum(xs) + self.find('b'))
         return output, self._monitors(output), ()
 

--- a/theanets/layers.py
+++ b/theanets/layers.py
@@ -6,6 +6,7 @@ import numpy as np
 import sys
 import theano
 import theano.tensor as TT
+import theano.sparse as SS
 
 from theano.sandbox.rng_mrg import MRG_RandomStreams as RandomStreams
 
@@ -13,6 +14,11 @@ logging = climate.get_logger(__name__)
 
 FLOAT = theano.config.floatX
 
+def myDot(x, y):
+    if isinstance(x, SS.SparseVariable):
+        return SS.structured_dot(x,y)
+    else:
+        return TT.dot(x,y)
 
 def random_matrix(nin, nout, mean=0, std=1, sparsity=0, radius=0):
     '''Create a matrix of randomly-initialized weights.
@@ -529,7 +535,7 @@ class Feedforward(Layer):
         '''
         if not hasattr(inputs, '__len__'):
             inputs = (inputs, )
-        xs = (TT.dot(x, self.find(str(i))) for i, x in enumerate(inputs))
+        xs = (myDot(x, self.find(str(i))) for i, x in enumerate(inputs))
         output = self.activate(sum(xs) + self.find('b'))
         return output, self._monitors(output), ()
 

--- a/theanets/trainer.py
+++ b/theanets/trainer.py
@@ -40,7 +40,6 @@ logging = climate.get_logger(__name__)
 
 FLOAT = theano.config.floatX
 
-
 def default_mapper(f, dataset, *args, **kwargs):
     '''Apply (map) a function to each element of a dataset.'''
     return [f(x, *args, **kwargs) for x in dataset]


### PR DESCRIPTION
This patch adds some support for sparse input vectors, speeding up the training for sparse input vectors considerably. Currently, the option to use sparse inputs apply only to FeedForward networks.