### PR TITLE
Handle unicode text

### DIFF
--- a/theanets/recurrent.py
+++ b/theanets/recurrent.py
@@ -88,7 +88,7 @@ class Text(object):
                 char for char, count in
                 collections.Counter(text).items()
                 if char != unknown and count >= min_count)))
-        self.text = re.sub(ur'[^{}]'.format(re.escape(self.alpha)), unknown, text)
+        self.text = re.sub(r'[^{}]'.format(re.escape(self.alpha)).encode('utf8'), unknown, text)
         assert unknown not in self.alpha
         self._rev_index = unknown + self.alpha
         self._fwd_index = dict(zip(self._rev_index, range(1 + len(self.alpha))))

--- a/theanets/recurrent.py
+++ b/theanets/recurrent.py
@@ -81,14 +81,14 @@ class Text(object):
         A string containing each character in the alphabet.
     '''
 
-    def __init__(self, text, alpha=None, min_count=2, unknown='\0'):
+    def __init__(self, text, alpha=None, min_count=2, unknown=u'\0'):
         self.alpha = alpha
         if self.alpha is None:
             self.alpha = ''.join(sorted(set(
                 char for char, count in
                 collections.Counter(text).items()
                 if char != unknown and count >= min_count)))
-        self.text = re.sub(r'[^{}]'.format(re.escape(self.alpha).encode('utf8')), unknown, text)
+        self.text = re.sub(unicode(r'[^{}]', 'utf-8').format(re.escape(self.alpha)), unknown, text)
         assert unknown not in self.alpha
         self._rev_index = unknown + self.alpha
         self._fwd_index = dict(zip(self._rev_index, range(1 + len(self.alpha))))

--- a/theanets/recurrent.py
+++ b/theanets/recurrent.py
@@ -88,7 +88,7 @@ class Text(object):
                 char for char, count in
                 collections.Counter(text).items()
                 if char != unknown and count >= min_count)))
-        self.text = re.sub(r'[^{}]'.format(re.escape(self.alpha)).encode('utf8'), unknown, text)
+        self.text = re.sub(r'[^{}]'.format(re.escape(self.alpha).encode('utf8')), unknown, text)
         assert unknown not in self.alpha
         self._rev_index = unknown + self.alpha
         self._fwd_index = dict(zip(self._rev_index, range(1 + len(self.alpha))))

--- a/theanets/recurrent.py
+++ b/theanets/recurrent.py
@@ -88,7 +88,7 @@ class Text(object):
                 char for char, count in
                 collections.Counter(text).items()
                 if char != unknown and count >= min_count)))
-        self.text = re.sub(r'[^{}]'.format(re.escape(self.alpha)), unknown, text)
+        self.text = re.sub(ur'[^{}]'.format(re.escape(self.alpha)), unknown, text)
         assert unknown not in self.alpha
         self._rev_index = unknown + self.alpha
         self._fwd_index = dict(zip(self._rev_index, range(1 + len(self.alpha))))


### PR DESCRIPTION
Attempting to use `theanets.recurrent.Text` on a UTF8 encoded corpus used to give an error

```
---------------------------------------------------------------------------
UnicodeEncodeError                        Traceback (most recent call last)
/home/fl350/bachbot/scripts/theanet/theanet.py in <module>()
     24 with codecs.open(path, 'r', 'utf-8') as handle:
     25     file_data = handle.read().lower()
---> 26     text = theanets.recurrent.Text(file_data[:int(VAL_FRACTION*len(file_data))])
     27     text_val = theanets.recurrent.Text(file_data[int(VAL_FRACTION*len(file_data)):])
     28

/home/fl350/theanets/theanets/recurrent.py in __init__(self, text, alpha, min_count, unknown)
     89                 collections.Counter(text).items()
     90                 if char != unknown and count >= min_count)))
---> 91         print type(r'[^{}]'.format(re.escape(self.alpha)).encode('utf8'))
     92         self.text = re.sub(r'[^{}]'.format(re.escape(self.alpha)).encode('utf8'), unknown, text)
     93         assert unknown not in self.alpha

UnicodeEncodeError: 'ascii' codec can't encode character u'\x83' in position 85: ordinal not in range(128)

```

This is fixed by this PR.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lmjohns3/theanets/131)

<!-- Reviewable:end -->
